### PR TITLE
Bump MarkupSafe from 1.1.1 to 2.0.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ docutils==0.14
 idna==3.7
 imagesize==1.1.0
 Jinja2==3.1.5
-MarkupSafe==1.1.1
+MarkupSafe==2.0.1
 packaging==19.0
 Pygments==2.15.0
 pyparsing==2.4.0


### PR DESCRIPTION
jinja2 3.1.5 depends on MarkupSafe>=2.0